### PR TITLE
Correcting wrong path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build: docker-builder
 .PHONY: _build
 _build: docker-image
 	@echo -e "$(COLOR_BLUE)### Build QPKG ...$(COLOR_RESET)"
-	fakeroot /usr/share/qdk2/QDK/bin/qbuild --build-dir $(BUILD_DIR) --xz amd64
+	fakeroot /usr/share/QDK/bin/qbuild --build-dir $(BUILD_DIR) --xz amd64
 
 .PHONY: docker-builder
 docker-builder:


### PR DESCRIPTION
If you clone the repository and make a make, it returns an error about a nonexistent file. Initially, the QDK is located in a different path. With this change, the make command is executed correctly.